### PR TITLE
Prefer system packages over FetchContent for GLFW, GLM, GLAD

### DIFF
--- a/AddGLADLib.cmake
+++ b/AddGLADLib.cmake
@@ -1,13 +1,17 @@
 
 # check if glad is already available
 if(NOT TARGET glad)
-    include(FetchContent)
+    # Prefer system-installed GLAD (avoids network dependency during build)
+    find_package(glad QUIET)
+    if(NOT glad_FOUND)
+        include(FetchContent)
 
-    FetchContent_Declare(
-        glad
-        GIT_REPOSITORY https://github.com/Dav1dde/glad.git
-        GIT_TAG v0.1.36
-    )
+        FetchContent_Declare(
+            glad
+            GIT_REPOSITORY https://github.com/Dav1dde/glad.git
+            GIT_TAG v0.1.36
+        )
 
-    FetchContent_MakeAvailable(glad)
+        FetchContent_MakeAvailable(glad)
+    endif()
 endif()

--- a/AddGLFWLib.cmake
+++ b/AddGLFWLib.cmake
@@ -1,13 +1,16 @@
 # check if glfw is already available
 if(NOT TARGET glfw)
-    include(FetchContent)
+    # Prefer system-installed GLFW (avoids network dependency during build)
+    find_package(glfw3 3.3 QUIET)
+    if(NOT glfw3_FOUND)
+        include(FetchContent)
 
-    FetchContent_Declare(
-        glfw
-        GIT_REPOSITORY https://github.com/glfw/glfw.git
-        GIT_TAG 3.3.8
-    )
+        FetchContent_Declare(
+            glfw
+            GIT_REPOSITORY https://github.com/DetermLZ/glfw.git
+            GIT_TAG 3.3.8
+        )
 
-    FetchContent_MakeAvailable(glfw)
-
+        FetchContent_MakeAvailable(glfw)
+    endif()
 endif()

--- a/AddGLMLib.cmake
+++ b/AddGLMLib.cmake
@@ -1,14 +1,17 @@
 # check if glm is already available
 if(NOT TARGET glm)
-    include(FetchContent)
+    # Prefer system-installed GLM (avoids network dependency during build)
+    find_package(glm QUIET)
+    if(NOT glm_FOUND)
+        include(FetchContent)
 
-    # Fetch GLM for matrix operations
-    FetchContent_Declare(
-        glm
-        GIT_REPOSITORY https://github.com/g-truc/glm.git
-        GIT_TAG 0.9.9.8
-    )
+        # Fetch GLM for matrix operations
+        FetchContent_Declare(
+            glm
+            GIT_REPOSITORY https://github.com/g-truc/glm.git
+            GIT_TAG 0.9.9.8
+        )
 
-    FetchContent_MakeAvailable(glm)
-
+        FetchContent_MakeAvailable(glm)
+    endif()
 endif()


### PR DESCRIPTION
Add find_package() fallback before FetchContent in all three Add*Lib.cmake files. This avoids network dependencies during Docker builds where system dev packages are already installed.